### PR TITLE
Gram HW1 Fix - Improve color contrast on events page

### DIFF
--- a/mayan/apps/appearance/static/appearance/css/base.css
+++ b/mayan/apps/appearance/static/appearance/css/base.css
@@ -394,7 +394,11 @@ a i {
 }
 
 .btn-danger.btn-outline {
-    color: #d9534f;
+  color: #a71d31;
+}
+
+.btn-danger {
+background-color: #a71d31;
 }
 
 .btn-default.btn-outline:hover,
@@ -648,4 +652,8 @@ a i {
     padding-top: 0px;
     padding-left: 0px;
     padding-right: 0px;
+}
+
+.table-striped a {
+  color: #0244A1;
 }

--- a/mayan/apps/appearance/templates/appearance/list_toolbar.html
+++ b/mayan/apps/appearance/templates/appearance/list_toolbar.html
@@ -38,7 +38,7 @@
                             {% ifequal page page_obj.number %}
                                 <a class="active btn btn-default btn-sm pagination-disabled" href="#">{{ page }}</a>
                             {% else %}
-                                <a class="btn btn-default btn-sm" href="?{{ page.querystring }}">{{ page }}</a>
+                                <a class="btn btn-default btn-sm" href="?{{ page.querystring }}" style="color: #0d151a;">{{ page }}</a>
                             {% endifequal %}
                         {% else %}
                             <a class="btn btn-default btn-sm disabled" href="#">...</a>


### PR DESCRIPTION
Addresses #16 by improving color contrast for key elements on the `/events/events` page.

Made btn-danger color darker
Changed color of links on table-striped to be dark blue instead of light green
Changed btn-toolbar text color to be dark gray instead of light gray when disabled
Improves Lighthouse accessibility score from 89 to 91.