### PR TITLE
Add models for review form data & Register new models to django admin site

### DIFF
--- a/mayan/apps/documents/admin.py
+++ b/mayan/apps/documents/admin.py
@@ -1,3 +1,8 @@
+from mayan.apps.documents.models.reviewer import Reviewer
+from mayan.apps.documents.models.reviewer_assignment import ReviewerAssignment
+from mayan.apps.documents.models.review import Review
+from mayan.apps.documents.models.metric import Metric
+from mayan.apps.documents.models.applicant import Applicant
 from django.contrib import admin
 
 from .models.document_models import Document
@@ -6,6 +11,13 @@ from .models.document_file_page_models import DocumentFilePage
 from .models.document_type_models import DocumentType, DocumentTypeFilename
 from .models.recently_accessed_document_models import RecentlyAccessedDocument
 from .models.trashed_document_models import TrashedDocument
+
+
+admin.site.register(Applicant)
+admin.site.register(Metric)
+admin.site.register(Review)
+admin.site.register(ReviewerAssignment)
+admin.site.register(Reviewer)
 
 
 class DocumentFilePageInline(admin.StackedInline):

--- a/mayan/apps/documents/models/__init__.py
+++ b/mayan/apps/documents/models/__init__.py
@@ -7,3 +7,8 @@ from .document_type_models import *  # NOQA
 from .favorite_document_models import *  # NOQA
 from .recently_accessed_document_models import *  # NOQA
 from .trashed_document_models import *  # NOQA
+from .applicant import * # NOQA
+from .metric import * #NOQA
+from .review import * #NOQA
+from .reviewer_assignment import * #NOQA
+from .reviewer import * #NOQA

--- a/mayan/apps/documents/models/applicant.py
+++ b/mayan/apps/documents/models/applicant.py
@@ -1,0 +1,7 @@
+from mayan.apps.documents.models.document_file_models import DocumentFile
+from django.db import models
+
+class Applicant(models.Model):
+    """Model that describes a grad school applicant"""
+    name = models.TextField()
+    resume = models.ForeignKey(to=DocumentFile, on_delete=models.CASCADE)

--- a/mayan/apps/documents/models/metric.py
+++ b/mayan/apps/documents/models/metric.py
@@ -1,0 +1,6 @@
+from mayan.apps.documents.models.document_file_models import DocumentFile
+from django.db import models
+
+class Metric(models.Model):
+    """Model that describes a metric"""
+    metric_name = models.TextField()

--- a/mayan/apps/documents/models/metric.py
+++ b/mayan/apps/documents/models/metric.py
@@ -4,3 +4,4 @@ from django.db import models
 class Metric(models.Model):
     """Model that describes a metric"""
     metric_name = models.TextField()
+    metric_type = models.TextField()

--- a/mayan/apps/documents/models/review.py
+++ b/mayan/apps/documents/models/review.py
@@ -1,0 +1,12 @@
+from mayan.apps.documents.models.applicant import Applicant
+from mayan.apps.documents.models.reviewer import Reviewer
+from django.db import models
+
+class Review(models.Model):
+    """Model that describes a review"""
+    reviewer = models.ForeignKey(to=Reviewer, on_delete=models.CASCADE)
+    applicant = models.ForeignKey(to=Applicant, on_delete=models.CASCADE)
+    # After discussing with Albert and James, we decided that the 
+    # evaluation should be a serialized string of a dictionary
+    # mapping from metric names to scores
+    evaluation = models.TextField()

--- a/mayan/apps/documents/models/reviewer.py
+++ b/mayan/apps/documents/models/reviewer.py
@@ -1,0 +1,5 @@
+from django.db import models
+
+class Reviewer(models.Model):
+    """Model that describes a reviewer on the admission committee"""
+    name = models.TextField()

--- a/mayan/apps/documents/models/reviewer_assignment.py
+++ b/mayan/apps/documents/models/reviewer_assignment.py
@@ -1,0 +1,9 @@
+from mayan.apps.documents.models.applicant import Applicant
+from mayan.apps.documents.models.reviewer import Reviewer
+from mayan.apps.documents.models.document_file_models import DocumentFile
+from django.db import models
+
+class ReviewerAssignment(models.Model):
+    """Model that describes a reviewer-application assignment"""
+    reviewer = models.ForeignKey(to=Reviewer, on_delete=models.CASCADE)
+    applicant = models.ForeignKey(to=Applicant, on_delete=models.CASCADE)


### PR DESCRIPTION
Completes #1 

The added models are
1. Applicant
2. Reviewer
3. Review
4. Reviewer Assignment
5. Metric

You can visit and test these models in Django's admin site.

Note: 
You might have to perform migration in your docker container after pulling this change to see the effect.
Here are the instructions for how to perform the migration in Mayan EDMS's docker container:
  Run docker image:
  $ docker-compose -f docker/docker-compose.yml up -d
  List docker image:
  $ docker containers ls
  Open CLI to docker image:
  $ docker exec -t -i yourDockerImageID bash
  (The above 2 steps can also be replaced by opening CLI from docker desktop, note that if you do this, it will open the sh shell instead of the bash shell, so you need to run $/bin/bash first to open the bash shell)
  cd to mayan folder
  $ cd /opt/mayan-edms/
  Open the python virtual environment    
  $ source bin/activate
  Now you can access manage.py file from
  $ python3 bin/mayan-edms.py makemigrations
  (Note that mayan “renames” manage.py to mayan-edms.py)
  $ python3 bin/mayan-edms.py migrate
  (Note that mayan “renames” manage.py to mayan-edms.py)